### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/dioscard/ee6e8b01-74f8-4544-abe7-bd27a2375ba6/30096a91-221f-4ea3-aa20-1ca0fba44ae7/_apis/work/boardbadge/c9fee60c-bf88-410c-9e22-7079250d2c01)](https://dev.azure.com/dioscard/ee6e8b01-74f8-4544-abe7-bd27a2375ba6/_boards/board/t/30096a91-221f-4ea3-aa20-1ca0fba44ae7/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/dioscard/ee6e8b01-74f8-4544-abe7-bd27a2375ba6/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.